### PR TITLE
[codex] Protect production host access

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,8 +3,46 @@ import { createRoot } from 'react-dom/client';
 import { Router } from './router';
 import './globals.css';
 
-createRoot(document.getElementById('root') as HTMLElement).render(
-  <StrictMode>
-    <Router />
-  </StrictMode>,
-);
+const ENCODING_KEY = 73;
+
+// Keep host values encoded so the plain domains are not directly searchable in built assets.
+const decodeValue = (encoded: number[]) =>
+  String.fromCharCode(...encoded.map((value) => value ^ ENCODING_KEY));
+
+const isAllowedHost = (hostname: string) => {
+  // localhost
+  const localHost = decodeValue([37, 38, 42, 40, 37, 33, 38, 58, 61]);
+  // .netlify.app
+  const netlifySuffix = decodeValue([
+    103, 39, 44, 61, 37, 32, 47, 48, 103, 40, 57, 57,
+  ]);
+
+  return hostname === localHost || hostname.endsWith(netlifySuffix);
+};
+
+const enforceAllowedHost = () => {
+  if (typeof window === 'undefined') {
+    return true;
+  }
+
+  if (isAllowedHost(window.location.hostname)) {
+    return true;
+  }
+
+  const redirectTarget = decodeValue([
+    // https://l2c-enchant.netlify.app
+    33, 61, 61, 57, 58, 115, 102, 102, 37, 123, 42, 100, 44, 39, 42, 33, 40, 39,
+    61, 103, 39, 44, 61, 37, 32, 47, 48, 103, 40, 57, 57,
+  ]);
+
+  window.location.replace(redirectTarget);
+  return false;
+};
+
+if (enforceAllowedHost()) {
+  createRoot(document.getElementById('root') as HTMLElement).render(
+    <StrictMode>
+      <Router />
+    </StrictMode>,
+  );
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,9 @@ import path from 'path';
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  build: {
+    sourcemap: false,
+  },
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),


### PR DESCRIPTION
## Summary
- add an early hostname guard in the app bootstrap so the UI only runs on `localhost` and `*.netlify.app`
- redirect unauthorized hosts to the canonical Netlify site before React mounts
- keep the allowed host values and redirect target encoded in source so the plain domains are not directly searchable in built assets
- explicitly disable Vite production source maps with `build.sourcemap = false`

## Why
The app is a static frontend, so a non-developer can copy the generated HTML and JS and host it elsewhere. This change adds a lightweight client-side restriction that blocks simple rehosting and sends traffic back to the canonical deployment.

## Notes
This is obfuscation, not strong copy protection. A technical attacker can still bypass it, but it raises the bar for simple HTML+JS copying.

## Validation
- `npm run check-types`
- `npm run build`
